### PR TITLE
Prepare for 5.2 AST bump

### DIFF
--- a/lib_ppx/deriver.ml
+++ b/lib_ppx/deriver.ml
@@ -299,7 +299,8 @@ let derive_type_declarations rec_flag type_declarations :
            { pvb_pat= generator_name
            ; pvb_expr= gen_expr
            ; pvb_attributes= []
-           ; pvb_loc= loc } )
+           ; pvb_loc= loc
+           ; pvb_constraint= None } )
   in
   Ast_builder.Default.pstr_value_list ~loc is_recursive bindings
 

--- a/lib_ppx/helpers.ml
+++ b/lib_ppx/helpers.ml
@@ -15,7 +15,7 @@ let rec is_type_var_used_in_core_type var_name (ct : core_type) : bool =
   | Ptyp_constr (_, args) ->
       List.exists (is_type_var_used_in_core_type var_name) args
   | Ptyp_alias (ct, s) ->
-      s = var_name || is_type_var_used_in_core_type var_name ct
+      s.txt = var_name || is_type_var_used_in_core_type var_name ct
   | Ptyp_poly (_, ct) ->
       is_type_var_used_in_core_type var_name ct
   | _ ->


### PR DESCRIPTION
This PR is a patch for an upcoming release of ppxlib where the internal AST is [bumped from 4.14 to 5.2](https://github.com/ocaml-ppx/ppxlib/pull/514). Until that is merged and released, there is no reason to merge this PR.

To test these changes, you can use the following opam-based workflow. I've made releases of most of these patches to an opam-repository overlay.

```shell
opam switch create ppxlib-bump --repos=ppxlib=git+https://github.com/patricoferris/opam-repository#5.2-ast-bump
opam install <your-package>
```

The following describes the most notable changes to the AST.

Note: no update has been made of the `opam` file, but `ppxlib` will likely need a lower-bound before merging/releasing.

### Functions
---

#### Currently 

In the parsetree currently, functions like:

```ocaml
fun x y z -> ...
```

Are represented roughly as

```ocaml
Pexp_fun(x, Pexp_fun (y, Pexp_fun(z, ...)))
```

Functions like:

```ocaml
function A -> ... | B -> ...
```

Are represented roughly as

```ocaml
Pexp_function ([ case A; case B ])
```

#### Since 5.2

All of these functions now map to a single AST node `Pexp_function` (note, this is the same name as the old cases function). The first argument is a list of parameters meaning:

```ocaml
fun x y z -> ...
```

Now looks like:

```ocaml
Pexp_function([x; y; z], _constraint, body)
```

And the `body` is where we can either have _more_ expressions (`Pfunction_body _`) or cases (`Pfunction_cases _`). That means:

```ocaml
function A -> ... | B -> ...
```

Has an empty list of parameters:

```ocaml
Pexp_function([], _, Pfunction_cases ([case A; case B]))
```

### Local Module Opens for Types

Another feature added in 5.2 was the ability to locally open modules in type definitions. 

```ocaml
module M = struct
  type t = A | B | C
end

type t = Local_open_coming of M.(t)
```

This has a `Ptyp_open (module_identifier, core_type)` AST node. Just like normal module opens this does create some syntactic ambiguity about where things come from inside the parentheses.
