### PR TITLE
Fix char generator root handling

### DIFF
--- a/lib_bam/std.ml
+++ b/lib_bam/std.ml
@@ -137,7 +137,7 @@ let bool ?(shrinker = Shrinker.Default) () =
 let char ?root ?(shrinker = Shrinker.Default) ?(printable = true) () =
   let base = if printable then Char.code 'a' else 0 in
   let max = if printable then 26 else 256 in
-  let root = root |> Option.map (fun root -> Char.code root - Char.code 'a') in
+  let root = root |> Option.map (fun root -> Char.code root - base) in
   match shrinker with
   | Manual shrinker ->
       let*! root = int ?root ~min:0 ~max () in

--- a/test/std.ml
+++ b/test/std.ml
@@ -33,6 +33,18 @@ let std_oneof () =
   let str = values |> List.map string_of_int |> String.concat " " in
   Regression.capture str ; Lwt.return_unit
 
+let std_char_custom_root () =
+  Test.register ~__FILE__ ~title:"std char custom root"
+    ~tags:["std"; "char"; "root"]
+  @@ fun () ->
+  let gen = Bam.Std.char ~printable:false ~root:(Char.chr 5) () in
+  let v =
+    Bam.Gen.run gen (Bam.Gen.Random.make [|0|]) |> Bam.Tree.root |> Char.code
+  in
+  if v = 5 then Lwt.return_unit
+  else Test.failf "expected 5 got %d" v
+
 let register () =
   std_int_range_inclusive_bounds () ;
-  std_oneof ()
+  std_oneof () ;
+  std_char_custom_root ()


### PR DESCRIPTION
## Summary
- fix root offset for Std.char generator so it respects printable setting
- add regression test ensuring char generator honors custom root

## Testing
- `dune runtest` *(fails: `dune: command not found`)*