### PR TITLE
Fix smallar typo in examples

### DIFF
--- a/example/2-simple-failure/README.md
+++ b/example/2-simple-failure/README.md
@@ -8,7 +8,7 @@ open Tezt_bam
 let register () =
   let gen = Std.int () in
   let property x =
-    if x < 100 then Ok () else Error (`Fail "integer is not smallar than 100")
+    if x < 100 then Ok () else Error (`Fail "integer is not smaller than 100")
   in
   Pbt.register ~pp:Format.pp_print_int ~__FILE__
     ~title:"Simple failure example with bam" ~tags:["bam"; "simple_failure"]
@@ -28,7 +28,7 @@ dune exec example/main.exe -- simple_failure
 [15:30:55.229] [pbt] Counter example found:
 [15:30:55.229] [pbt] 323253551143260932
 [15:30:55.229] [error] Test failed with error:
-[15:30:55.229] [error] integer is not smallar than 100
+[15:30:55.229] [error] integer is not smaller than 100
 [15:30:55.229] [FAILURE] (1/1, 1 failed) Simple failure example with bam
 [15:30:55.229] Try again with: _build/default/example/main.exe --verbose --file example/2-simple-failure/simple_failure.ml --title 'Simple failure example with bam' --seed 555586205
 ```
@@ -47,7 +47,7 @@ $ dune exec example/main.exe -- simple_failure --shrink --seed 555586205
 [15:36:00.803] [pbt] Counter example found:
 [15:36:00.803] [pbt] 100
 [15:36:00.803] [error] Test failed with error:
-[15:36:00.803] [error] integer is not smallar than 100
+[15:36:00.803] [error] integer is not smaller than 100
 [15:36:00.803] [FAILURE] (1/1, 1 failed) Simple failure example with bam
 [15:36:00.803] Try again with: _build/default/example/main.exe --verbose --file example/2-simple-failure/simple_failure.ml --title 'Simple failure example with bam' --seed 555586205
 ```

--- a/example/2-simple-failure/simple_failure.ml
+++ b/example/2-simple-failure/simple_failure.ml
@@ -3,7 +3,7 @@ open Tezt_bam
 let register () =
   let gen = Std.int () in
   let property x =
-    if x < 100 then Ok () else Error (`Fail "integer is not smallar than 100")
+    if x < 100 then Ok () else Error (`Fail "integer is not smaller than 100")
   in
   Pbt.register ~pp:Format.pp_print_int ~__FILE__
     ~title:"Simple failure example with bam" ~tags:["bam"; "simple_failure"]

--- a/example/6-debugging/README.md
+++ b/example/6-debugging/README.md
@@ -10,7 +10,7 @@ let register () =
   let property x =
     Format.eprintf "HEY: %d@." x ;
     if x < 100 && x <> 16 then Ok ()
-    else Error (`Fail "integer is not smallar than 100")
+    else Error (`Fail "integer is not smaller than 100")
   in
   Pbt.register ~pp:Format.pp_print_int ~__FILE__ ~title:"Debugging with bam"
     ~tags:["bam"; "debugging"] ~gen ~property ()
@@ -27,7 +27,7 @@ HEY: 1531078954999384395
 [15:46:01.805] [pbt] Counter example found:
 [15:46:01.805] [pbt] 100
 [15:46:01.805] [error] Test failed with error:
-[15:46:01.805] [error] integer is not smallar than 100
+[15:46:01.805] [error] integer is not smaller than 100
 [15:46:01.805] [FAILURE] (1/1, 1 failed) Debugging with bam
 [15:46:01.805] Try again with: _build/default/example/main.exe --verbose --file example/3-debugging/debugging.ml --title 'Debugging with bam' --seed 830377664
 ```
@@ -60,7 +60,7 @@ HEY: 16
 [16:08:35.821] [pbt] Counter example found:
 [16:08:35.821] [pbt] 16
 [16:08:35.821] [error] Test failed with error:
-[16:08:35.821] [error] integer is not smallar than 100
+[16:08:35.821] [error] integer is not smaller than 100
 [16:08:35.821] [FAILURE] (1/1, 1 failed) Debugging with bam
 [16:08:35.821] Try again with: _build/default/example/main.exe --verbose --file example/3-debugging/debugging.ml --title 'Debugging with bam' --seed 353027053
 ```

--- a/example/6-debugging/debugging.ml
+++ b/example/6-debugging/debugging.ml
@@ -5,7 +5,7 @@ let register () =
   let property x =
     Format.eprintf "HEY: %d@." x ;
     if x < 100 && x <> 16 then Ok ()
-    else Error (`Fail "integer is not smallar than 100")
+    else Error (`Fail "integer is not smaller than 100")
   in
   Pbt.register ~pp:Format.pp_print_int ~__FILE__ ~title:"Debugging with bam"
     ~tags:["bam"; "debugging"] ~gen ~property ()


### PR DESCRIPTION
## Summary
- fix "smallar" typo in example source code
- update readmes to show updated error string

## Testing
- `dune runtest` *(fails: command not found)*