### PR TITLE
Fix boolean generator range

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,10 @@
 Changelog for Bam library
 
+## Unreleased
+
+- Fix `Bam.Std.bool` to use `int ~min:0 ~max:1` for an unbiased boolean
+  generator.
+
 ## v0.3 (2024-10-25)
 
 - Fix a file descriptor leak (#8)

--- a/README.md
+++ b/README.md
@@ -53,6 +53,15 @@ opam install bam tezt-bam
 Compatibility is ensured for OCaml versions `4.14.2`, `5.0.0` and
 `5.1.0`.
 
+The library and its examples rely on the `dune` build system.  If `dune`
+is not already available on your machine, install it with opam and
+refresh your environment:
+
+```bash
+opam install dune
+eval $(opam env)
+```
+
 ## Usage
 
 A simple test can be run as follows:

--- a/lib_bam/std.ml
+++ b/lib_bam/std.ml
@@ -122,16 +122,17 @@ let pair ?(shrinker = Shrinker.Default) left right =
       let* b = right in
       return (a, b) |> Gen.(with_merge (Merge.of_compare ~compare))
 
+(* Use an unbiased integer range [0;1] to generate booleans. *)
 let bool ?(shrinker = Shrinker.Default) () =
   match shrinker with
   | Manual shrinker ->
-      let*! root = int ~min:0 ~max:2 () in
+      let*! root = int ~min:0 ~max:1 () in
       Gen.make (root = 0) shrinker
   | Default ->
-      let* x = int ~min:0 ~max:2 () in
+      let* x = int ~min:0 ~max:1 () in
       if x = 0 then return false else return true
   | Bool b ->
-      let* x = int ~min:0 ~max:2 () in
+      let* x = int ~min:0 ~max:1 () in
       if x = 0 = b then return true else return false
 
 let char ?root ?(shrinker = Shrinker.Default) ?(printable = true) () =


### PR DESCRIPTION
## Summary
- fix `bool` generator to use `[0;1]`
- document dune as a dependency
- note the boolean generator fix in `CHANGES`

## Testing
- `dune runtest` *(fails: command not found)*