### PR TITLE
Fix opam install sudo issue in workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
         run: |
           opam update
           opam upgrade
-          opam install . --deps-only -t
+          opam install . --deps-only -t --yes --no-depexts
       - name: Build Bam
         run: |
           eval $(opam env)


### PR DESCRIPTION
## Summary
- avoid running `sudo` via opam depext by disabling depexts

## Testing
- `git status --short`