### PR TITLE
Fix ocaml setup action in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: setting up opam...
-        uses: ocaml/setup-ocaml@v2
+        uses: ocaml/setup-ocaml@v3
         with:
           ocaml-compiler: ${{ matrix.ocaml-compiler }}
       - name: Install dependencies


### PR DESCRIPTION
## Summary
- use `ocaml/setup-ocaml@v3` in CI
- remove unnecessary depext flags when installing dependencies

## Testing
- `dune runtest` *(fails: Unbound value Test.failf)*
